### PR TITLE
feat: To Do Summary 화면 구성 및 기능 구현

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,6 +8,7 @@ import { useAtomValue } from "jotai";
 import { tabAtom } from "./atoms/tabAtom";
 import { Tabs } from "./enums/tabs";
 import ToDoTimer from "./components/to-do-timer/ToDoTimer";
+import ToDoSummary from "./components/to-do-summary/ToDoSummary";
 
 const Container = styled.div`
     height: 100vh;
@@ -26,6 +27,7 @@ function App() {
             <Container>
                 {currentTab === Tabs.Home && <NoTaskBox />}
                 {currentTab === Tabs.Task && <ToDo />}
+                {currentTab === Tabs.Summary && <ToDoSummary />}
                 {currentTab === Tabs.ToDoTimer && <ToDoTimer />}
             </Container>
         </ThemeProvider>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,11 +4,13 @@ import { GlobalStyle } from "./styles/GlobalStyle";
 import { ThemeProvider } from "./contexts/ThemeContext";
 import Header from "./components/headers/Header";
 import ToDo from "./components/to-do/ToDo";
-import { useAtomValue } from "jotai";
+import { useAtom, useAtomValue } from "jotai";
 import { tabAtom } from "./atoms/tabAtom";
 import { Tabs } from "./enums/tabs";
 import ToDoTimer from "./components/to-do-timer/ToDoTimer";
 import ToDoSummary from "./components/to-do-summary/ToDoSummary";
+import { loadTask } from "./utils/utils";
+import { useEffect } from "react";
 
 const Container = styled.div`
     height: 100vh;
@@ -18,7 +20,14 @@ const Container = styled.div`
 `;
 
 function App() {
-    const currentTab = useAtomValue(tabAtom);
+    const [currentTab, setCurrentTab] = useAtom(tabAtom);
+
+    useEffect(() => {
+        const task = loadTask();
+        const tab = task ? Tabs.Summary : Tabs.Home;
+
+        setCurrentTab(tab);
+    }, []);
 
     return (
         <ThemeProvider>

--- a/src/atoms/tabAtom.ts
+++ b/src/atoms/tabAtom.ts
@@ -1,4 +1,4 @@
 import { atom } from "jotai";
 import { Tabs } from "../enums/tabs";
 
-export const tabAtom = atom<Tabs>(Tabs.Home);
+export const tabAtom = atom<Tabs>(Tabs.None);

--- a/src/components/to-do-summary/ToDoSummary.tsx
+++ b/src/components/to-do-summary/ToDoSummary.tsx
@@ -6,6 +6,7 @@ import delete_dark from "../../assets/delete_black.svg";
 import { useSetAtom } from "jotai";
 import { tabAtom } from "../../atoms/tabAtom";
 import { Tabs } from "../../enums/tabs";
+import { loadTask } from "../../utils/utils";
 
 const Wrapper = styled.div`
     padding: 20px;
@@ -77,10 +78,9 @@ function ToDoSummary() {
     const { darkMode } = useTheme();
     const setCurrentTab = useSetAtom(tabAtom);
 
-    let task;
-    try {
-        task = JSON.parse(localStorage.getItem("task") || "");
-    } catch (err) {
+    const task = loadTask();
+    
+    if (!task) {
         alert("데이터를 불러올 수 없습니다.");
         return;
     }
@@ -95,7 +95,7 @@ function ToDoSummary() {
     }
 
     function editTask() {
-        console.log("edit task");
+        setCurrentTab(Tabs.Task);
     }
 
     return (

--- a/src/components/to-do-summary/ToDoSummary.tsx
+++ b/src/components/to-do-summary/ToDoSummary.tsx
@@ -1,0 +1,121 @@
+import { styled } from "styled-components";
+import { useTheme } from "../../contexts/ThemeContext";
+import EmojiCard from "../to-do/EmojiCard";
+import delete_white from "../../assets/delete_white.svg";
+import delete_dark from "../../assets/delete_black.svg";
+
+const Wrapper = styled.div`
+    padding: 20px;
+    min-width: 380px;
+    border: 1px solid #ccc;
+    border-radius: 40px;
+`;
+
+const Header = styled.div`
+    position: relative;
+    display: flex;
+    justify-content: space-between;
+`;
+
+const DeleteButton = styled.button`
+    all: unset;
+    cursor: pointer;
+    width: 40px;
+    height: 40px;
+    color: ${(props) => props.theme.button.normal.text};
+    text-align: center;
+    border-radius: 10px;
+    background-color: transparent;
+
+    &:hover {
+        background-color: ${(props) => props.theme.button.normal.bg};
+    }
+    &:active {
+        background-color: ${(props) => props.theme.button.active.bg};
+    }
+`;
+
+const Summary = styled.div`
+    margin-bottom: 30px;
+    padding-left: 5px;
+    font-weight: 400;
+    color: ${(props) => props.theme.button.normal.text};
+`;
+
+const Buttons = styled.div`
+    width: 100%;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+`;
+
+const Button = styled.button`
+    all: unset;
+    cursor: pointer;
+    width: 160px;
+    height: 50px;
+    background-color: ${(props) => props.theme.button.normal.bg};
+    border: 1px solid ${(props) => props.theme.button.normal.border};
+    border-radius: 25px;
+    color: ${(props) => props.theme.button.normal.text};
+    text-align: center;
+
+    &:hover {
+        background-color: ${(props) => props.theme.button.hover.bg};
+        border-color: ${(props) => props.theme.button.hover.border};
+    }
+    &:active {
+        background-color: ${(props) => props.theme.button.active.bg};
+        border-color: ${(props) => props.theme.button.active.border};
+    }
+`;
+
+function ToDoSummary() {
+    const { darkMode } = useTheme();
+
+    let task;
+    try {
+        task = JSON.parse(localStorage.getItem("task") || "");
+    } catch (err) {
+        alert("데이터를 불러올 수 없습니다.");
+        return;
+    }
+
+    function deleteTask() {
+        console.log("delete task.");
+    }
+
+    function startTask() {
+        console.log("start task");
+    }
+
+    function editTask() {
+        console.log("edit task");
+    }
+
+    return (
+        <Wrapper>
+            <Header>
+                <EmojiCard
+                    backgroundColor={task["color"]}
+                    emoji={task["emoji"]}
+                    selectEmoji={undefined}
+                />
+                <DeleteButton onClick={deleteTask}>
+                    <img src={darkMode ? delete_white : delete_dark} />
+                </DeleteButton>
+            </Header>
+            <Summary>
+                <span>
+                    {task["toDo"]} for {task["timer"]} minutes
+                </span>
+            </Summary>
+            <Buttons>
+                <Button onClick={editTask}>Edit</Button>
+                <Button onClick={startTask}>Start</Button>
+            </Buttons>
+        </Wrapper>
+    );
+}
+
+export default ToDoSummary;

--- a/src/components/to-do-summary/ToDoSummary.tsx
+++ b/src/components/to-do-summary/ToDoSummary.tsx
@@ -3,6 +3,9 @@ import { useTheme } from "../../contexts/ThemeContext";
 import EmojiCard from "../to-do/EmojiCard";
 import delete_white from "../../assets/delete_white.svg";
 import delete_dark from "../../assets/delete_black.svg";
+import { useSetAtom } from "jotai";
+import { tabAtom } from "../../atoms/tabAtom";
+import { Tabs } from "../../enums/tabs";
 
 const Wrapper = styled.div`
     padding: 20px;
@@ -72,6 +75,7 @@ const Button = styled.button`
 
 function ToDoSummary() {
     const { darkMode } = useTheme();
+    const setCurrentTab = useSetAtom(tabAtom);
 
     let task;
     try {
@@ -82,7 +86,8 @@ function ToDoSummary() {
     }
 
     function deleteTask() {
-        console.log("delete task.");
+        localStorage.removeItem("task");
+        setCurrentTab(Tabs.Home);
     }
 
     function startTask() {

--- a/src/components/to-do-summary/ToDoSummary.tsx
+++ b/src/components/to-do-summary/ToDoSummary.tsx
@@ -91,7 +91,7 @@ function ToDoSummary() {
     }
 
     function startTask() {
-        console.log("start task");
+        setCurrentTab(Tabs.ToDoTimer);
     }
 
     function editTask() {

--- a/src/components/to-do-summary/ToDoSummary.tsx
+++ b/src/components/to-do-summary/ToDoSummary.tsx
@@ -97,6 +97,7 @@ function ToDoSummary() {
         <Wrapper>
             <Header>
                 <EmojiCard
+                    isClickable={false}
                     backgroundColor={task["color"]}
                     emoji={task["emoji"]}
                     selectEmoji={undefined}

--- a/src/components/to-do-timer/ToDoTimer.tsx
+++ b/src/components/to-do-timer/ToDoTimer.tsx
@@ -1,6 +1,10 @@
 import styled from "styled-components";
 import Button from "./Button";
 import { useEffect, useRef, useState } from "react";
+import { loadTask } from "../../utils/utils";
+import { useSetAtom } from "jotai";
+import { tabAtom } from "../../atoms/tabAtom";
+import { Tabs } from "../../enums/tabs";
 
 const Wrapper = styled.div`
     display: flex;
@@ -56,14 +60,18 @@ const Buttons = styled.div`
 `;
 
 function ToDoTimer() {
-    let timer;
-    try {
-        const task = JSON.parse(localStorage.getItem("task") || "");
-        timer = parseInt(task["timer"]);
-    } catch (err) {
+    const setCurrentTab = useSetAtom(tabAtom);
+
+    const task = loadTask();
+
+    if (!task) {
         alert("데이터를 불러올 수 없습니다.");
+        setCurrentTab(Tabs.Home);
+
         return;
     }
+
+    const timer = task["timer"];
 
     const [seconds, setSeconds] = useState(timer * 60);
     const [isRunning, setIsRunning] = useState(true);
@@ -93,10 +101,8 @@ function ToDoTimer() {
     }
 
     function cancelTimer() {
-        setIsRunning(false);
-
-        // TODO: 이전 화면으로 돌아가기
-        console.log("이전 화면으로 돌아가기");
+        finishTimer();
+        setCurrentTab(Tabs.Summary);
     }
 
     function finishTimer() {

--- a/src/components/to-do/EmojiCard.tsx
+++ b/src/components/to-do/EmojiCard.tsx
@@ -2,8 +2,8 @@ import { useState } from "react";
 import { styled } from "styled-components";
 import EmojiPicker, { type EmojiClickData } from "emoji-picker-react";
 
-const Card = styled.div<{ $bgColor: string }>`
-    cursor: pointer;
+const Card = styled.div<{ $isClickable: boolean; $bgColor: string }>`
+    cursor: ${(props) => (props.$isClickable ? "pointer" : "unset")};
     margin-bottom: 20px;
     width: 60px;
     height: 60px;
@@ -29,12 +29,18 @@ const EmojiPickerBackground = styled.div`
 `;
 
 interface IProp {
+    isClickable: boolean;
     backgroundColor: string;
     emoji: string;
     selectEmoji: ((data: EmojiClickData) => void) | undefined;
 }
 
-function EmojiCard({ backgroundColor, emoji, selectEmoji }: IProp) {
+function EmojiCard({
+    isClickable,
+    backgroundColor,
+    emoji,
+    selectEmoji,
+}: IProp) {
     const [showEmojiPicker, setShowEmojiPicker] = useState(false);
 
     function handleEmojiPicker() {
@@ -43,7 +49,11 @@ function EmojiCard({ backgroundColor, emoji, selectEmoji }: IProp) {
 
     return (
         <>
-            <Card onClick={handleEmojiPicker} $bgColor={backgroundColor}>
+            <Card
+                onClick={isClickable ? handleEmojiPicker : undefined}
+                $isClickable={isClickable}
+                $bgColor={backgroundColor}
+            >
                 <span>{emoji}</span>
             </Card>
             {showEmojiPicker && (

--- a/src/components/to-do/EmojiCard.tsx
+++ b/src/components/to-do/EmojiCard.tsx
@@ -31,7 +31,7 @@ const EmojiPickerBackground = styled.div`
 interface IProp {
     backgroundColor: string;
     emoji: string;
-    selectEmoji: (data: EmojiClickData) => void;
+    selectEmoji: ((data: EmojiClickData) => void) | undefined;
 }
 
 function EmojiCard({ backgroundColor, emoji, selectEmoji }: IProp) {

--- a/src/components/to-do/ToDo.tsx
+++ b/src/components/to-do/ToDo.tsx
@@ -77,8 +77,7 @@ function ToDo() {
     function onClickCancelBtn() {
         const item = localStorage.getItem("task");
         if (item) {
-            // TODO: 타이머 탭으로 전환
-            console.log("타이머 탭으로 전환");
+            setCurrentTab(Tabs.Summary);
         } else {
             setCurrentTab(Tabs.Home);
         }
@@ -121,8 +120,7 @@ function ToDo() {
         };
 
         localStorage.setItem("task", JSON.stringify(result));
-
-        // TODO: 타이머 탭으로 전환
+        setCurrentTab(Tabs.Summary);
     }
 
     return (

--- a/src/components/to-do/ToDo.tsx
+++ b/src/components/to-do/ToDo.tsx
@@ -11,6 +11,7 @@ import EmojiCard from "./EmojiCard";
 import { useSetAtom } from "jotai";
 import { tabAtom } from "../../atoms/tabAtom";
 import { Tabs } from "../../enums/tabs";
+import { loadTask } from "../../utils/utils";
 
 const Form = styled.form`
     padding: 20px;
@@ -74,23 +75,6 @@ function ToDo() {
     const { darkMode } = useTheme();
     const setCurrentTab = useSetAtom(tabAtom);
 
-    function onClickCancelBtn() {
-        const item = localStorage.getItem("task");
-        if (item) {
-            setCurrentTab(Tabs.Summary);
-        } else {
-            setCurrentTab(Tabs.Home);
-        }
-    }
-
-    const [emoji, setEmoji] = useState("🧭");
-
-    function selectEmoji(data: EmojiClickData) {
-        setEmoji(data.emoji);
-    }
-
-    const [toDo, setToDo] = useState("");
-
     const colors = [
         "#ff7675",
         "#fdcb6e",
@@ -100,14 +84,40 @@ function ToDo() {
         "#e84393",
         "#b2bec3",
     ];
-    const [color, setColor] = useState(colors[0]);
-    const [timer, setTimer] = useState(25);
+
+    let task = loadTask();
+    
+    if (!task) {
+        task = {
+            emoji: "🧭",
+            toDo: "",
+            color: colors[0],
+            timer: 25
+        }
+    }
+
+    const [emoji, setEmoji] = useState(task["emoji"]);
+    const [toDo, setToDo] = useState(task["toDo"]);
+    const [color, setColor] = useState(task["color"]);
+    const [timer, setTimer] = useState(task["timer"]);
+
+    function selectEmoji(data: EmojiClickData) {
+        setEmoji(data.emoji);
+    }
+
     function minusTimer() {
         setTimer((prev) => Math.max(15, prev - 1));
     }
 
     function plusTimer() {
         setTimer((prev) => Math.min(prev + 1, 35));
+    }
+
+    function onClickCancelBtn() {
+        const item = localStorage.getItem("task");
+        const tab = item ? Tabs.Summary : Tabs.Home;
+        
+        setCurrentTab(tab);
     }
 
     function handleSubmit(event: React.FormEvent) {

--- a/src/components/to-do/ToDo.tsx
+++ b/src/components/to-do/ToDo.tsx
@@ -130,6 +130,7 @@ function ToDo() {
             <Form onSubmit={handleSubmit}>
                 <FormHeader>
                     <EmojiCard
+                        isClickable={true}
                         backgroundColor={color}
                         emoji={emoji}
                         selectEmoji={selectEmoji}

--- a/src/enums/tabs.ts
+++ b/src/enums/tabs.ts
@@ -1,4 +1,5 @@
 export const Tabs = {
+    None: "none",
     Home: "no task",
     Task: "task",
     Summary: "summary",

--- a/src/enums/tabs.ts
+++ b/src/enums/tabs.ts
@@ -1,6 +1,7 @@
 export const Tabs = {
     Home: "no task",
     Task: "task",
+    Summary: "summary",
     ToDoTimer: "ToDo Timer",
 } as const;
 

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -1,0 +1,11 @@
+interface Task {
+    emoji: string;
+    toDo: string;
+    color: string;
+    timer: number;
+}
+
+export function loadTask() {
+    const task = localStorage.getItem("task");
+    return task ? (JSON.parse(task) as Task) : undefined;
+}


### PR DESCRIPTION
## 작업 내용

### `To Do Summary` 화면 구현
- 사용자가 입력한 `task`를 확인할 수 있는 화면
- `To Do Summary` 화면에서는 `EmojiCard`를 클릭해도 이모지 수정이 불가
- `Start` 버튼을 눌러 타이머 시작
- `Edit` 버튼을 눌러 `task` 수정 화면으로 이동

### 탭 분기 처리
- 초기 로딩 시 `localStorage`에 `task`가 저장됐는지 확인
- 저장된 `task`가 있으면 `To Do Summary` 탭 표시
- 저장된 `task`가 없으면 `Home` 탭 표시

### `task` 불러오는 util 함수 제작
- 전역에서 재사용할 수 있는 util 함수 제작
- 저장된 `task` 데이터가 없으면 `undefined` 반환